### PR TITLE
ci: publish GoReleaser drafts after artifact upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,3 +52,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.REGISTRY_PAT }}
         continue-on-error: true
+      - name: Publish GitHub release
+        if: ${{ success() }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release edit "${{ github.ref_name }}" --draft=false --repo "${{ github.repository }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,25 +35,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASES_TOKEN }}
 
-  notify-registry:
+  publish-release:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [release]
     permissions:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      - name: Notify workflow-registry
-        if: env.GH_TOKEN != ''
-        uses: peter-evans/repository-dispatch@v3
-        with:
-          token: ${{ secrets.REGISTRY_PAT }}
-          repository: GoCodeAlone/workflow-registry
-          event-type: plugin-release
-          client-payload: >-
-            {"plugin": "${{ github.repository }}", "tag": "${{ github.ref_name }}"}
-        env:
-          GH_TOKEN: ${{ secrets.REGISTRY_PAT }}
-        continue-on-error: true
       - name: Publish GitHub release
         uses: actions/github-script@v7
         with:
@@ -70,3 +58,21 @@ jobs:
                 draft: false,
               });
             }
+
+  notify-registry:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: [publish-release]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify workflow-registry
+        if: env.GH_TOKEN != ''
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.REGISTRY_PAT }}
+          repository: GoCodeAlone/workflow-registry
+          event-type: plugin-release
+          client-payload: >-
+            {"plugin": "${{ github.repository }}", "tag": "${{ github.ref_name }}"}
+        env:
+          GH_TOKEN: ${{ secrets.REGISTRY_PAT }}
+        continue-on-error: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,9 @@ env:
   GONOSUMDB: github.com/GoCodeAlone/*
   GOPRIVATE: github.com/GoCodeAlone/*
 
+permissions:
+  contents: write
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -53,7 +56,18 @@ jobs:
           GH_TOKEN: ${{ secrets.REGISTRY_PAT }}
         continue-on-error: true
       - name: Publish GitHub release
-        if: ${{ success() }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release edit "${{ github.ref_name }}" --draft=false --repo "${{ github.repository }}"
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.RELEASES_TOKEN || github.token }}
+          script: |
+            const tag = context.ref.replace('refs/tags/', '');
+            const { owner, repo } = context.repo;
+            const { data: release } = await github.rest.repos.getReleaseByTag({ owner, repo, tag });
+            if (release.draft) {
+              await github.rest.repos.updateRelease({
+                owner,
+                repo,
+                release_id: release.id,
+                draft: false,
+              });
+            }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,9 +10,6 @@ env:
   GONOSUMDB: github.com/GoCodeAlone/*
   GOPRIVATE: github.com/GoCodeAlone/*
 
-permissions:
-  contents: write
-
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -41,6 +38,8 @@ jobs:
   notify-registry:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [release]
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Notify workflow-registry
@@ -58,9 +57,9 @@ jobs:
       - name: Publish GitHub release
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.RELEASES_TOKEN || github.token }}
+          github-token: ${{ github.token }}
           script: |
-            const tag = context.ref.replace('refs/tags/', '');
+            const tag = process.env.GITHUB_REF_NAME;
             const { owner, repo } = context.repo;
             const { data: release } = await github.rest.repos.getReleaseByTag({ owner, repo, tag });
             if (release.draft) {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,16 @@ jobs:
           script: |
             const tag = process.env.GITHUB_REF_NAME;
             const { owner, repo } = context.repo;
-            const { data: release } = await github.rest.repos.getReleaseByTag({ owner, repo, tag });
+            let release;
+            try {
+              ({ data: release } = await github.rest.repos.getReleaseByTag({ owner, repo, tag }));
+            } catch (error) {
+              if (error.status === 404) {
+                core.setFailed(`No GitHub release found for ${tag}; ensure GoReleaser created the draft before publishing.`);
+                return;
+              }
+              throw error;
+            }
             if (release.draft) {
               await github.rest.repos.updateRelease({
                 owner,

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,3 +10,6 @@ changelog:
       - '^docs:'
       - '^test:'
       - '^chore:'
+
+release:
+  draft: true


### PR DESCRIPTION
## Summary
- configure GoReleaser to keep GitHub releases as drafts while release assets are uploaded
- publish the draft after release artifacts are attached, before downstream registry notifications that need public release assets
- keep release workflows compatible with GitHub immutable releases

## Verification
- actionlint on changed GoReleaser release workflow
- git diff --check