### PR TITLE
ci: fix notify-registry draft-state release lookup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,14 +50,13 @@ jobs:
             const tag = process.env.GITHUB_REF_NAME;
             const { owner, repo } = context.repo;
             let release;
-            try {
-              ({ data: release } = await github.rest.repos.getReleaseByTag({ owner, repo, tag }));
-            } catch (error) {
-              if (error.status === 404) {
-                core.setFailed(`No GitHub release found for ${tag}; ensure GoReleaser created the draft before publishing.`);
-                return;
-              }
-              throw error;
+            // listReleases returns drafts; getReleaseByTag 404s on drafts. GoReleaser
+            // creates releases as draft; this step flips them to non-draft post-publish.
+            const { data: releases } = await github.rest.repos.listReleases({ owner, repo, per_page: 100 });
+            release = releases.find(r => r.tag_name === tag);
+            if (!release) {
+              core.setFailed(`No GitHub release found for ${tag} in repo listing (latest 100); ensure GoReleaser created it before publishing.`);
+              return;
             }
             if (release.draft) {
               await github.rest.repos.updateRelease({


### PR DESCRIPTION
## Summary

Fixes recurring notify-registry failure across plugin release workflows: `Publish GitHub release` step uses `github.rest.repos.getReleaseByTag` which returns 404 for DRAFT releases. GoReleaser config creates releases as draft → step fails on every release.

## Root cause

`getReleaseByTag` only returns published (non-draft) releases. Drafts have no tag indexing — accessible only by release ID.

## Fix

Replace with `listReleases` (which DOES return drafts) + find by tag. Single deterministic API call; no 404-on-draft race.

Note: this repo had wrapped getReleaseByTag in try/catch handling 404; replaced with simpler listReleases + null-check.

## Sibling PRs

8 sibling PRs (gcp, azure, authz, authz-ui, bento, security, supply-chain, tofu) ship the same fix across other affected plugin repos.

## Test plan

- [x] YAML parses cleanly
- [ ] Next release tag exercises the fixed path

## Rollback

Revert commit.