### PR TITLE
docs(agent): verified banner + CONTRIBUTING + examples + CHANGELOG (QoL sweep)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug report
+about: Report a bug in this plugin
+title: '[Bug] '
+labels: bug
+assignees: ''
+---
+
+## Describe the bug
+
+A clear and concise description of what the bug is.
+
+## To reproduce
+
+Steps to reproduce the behavior:
+1. Config used (redact any secrets)
+2. Command run
+3. Error output
+
+## Expected behavior
+
+What you expected to happen.
+
+## Environment
+
+- workflow engine version: <!-- e.g. 0.3.51 -->
+- plugin version: <!-- e.g. 1.0.0 -->
+- Go version: <!-- go version -->
+- OS: <!-- e.g. linux/amd64, darwin/arm64 -->
+
+## Additional context
+
+Add any other context or logs here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,27 @@
+---
+name: Feature request
+about: Suggest a new capability for this plugin
+title: '[Feature] '
+labels: enhancement
+assignees: ''
+---
+
+## Summary
+
+A one-sentence description of the feature.
+
+## Motivation
+
+Why is this feature needed? What problem does it solve?
+
+## Proposed solution
+
+How would you like it to work? Include config schema changes if relevant.
+
+## Alternatives considered
+
+Any alternative approaches you considered and why you ruled them out.
+
+## Additional context
+
+Links, screenshots, or related issues.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+## Summary
+
+<!-- What does this PR do? 1-3 bullet points. -->
+
+## Motivation
+
+<!-- Why is this change needed? Link to issue if applicable. Closes #NNN -->
+
+## Test plan
+
+- [ ] `go build ./...` passes
+- [ ] `go vet ./...` passes
+- [ ] `go test ./...` passes
+- [ ] Manual smoke test (describe)
+
+## Checklist
+
+- [ ] CHANGELOG.md updated (Keep-a-Changelog format)
+- [ ] No secrets or credentials included
+- [ ] One feature or bugfix per PR

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+- README verified-status banner per workflow#714 (multi-repo QoL sweep).
+- CONTRIBUTING.md, examples/minimal/config.yaml, and GitHub issue/PR templates.
+
+## [v0.9.3] - 2026-05-19
+
+Initial CHANGELOG entry tracking the current release. See git tags for prior versions.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+# Contributing to workflow-plugin-agent
+
+This plugin is part of the [GoCodeAlone/workflow](https://github.com/GoCodeAlone/workflow) ecosystem.
+
+## Before contributing
+
+Read the [upstream CONTRIBUTING.md](https://github.com/GoCodeAlone/workflow/blob/main/CONTRIBUTING.md) for general conventions, signing, and review expectations.
+
+## Local development
+
+```sh
+git clone https://github.com/GoCodeAlone/workflow-plugin-agent.git
+cd workflow-plugin-agent
+go build ./...
+go test ./...
+```
+
+## Pull requests
+
+- One feature or bugfix per PR.
+- Update CHANGELOG.md with a Keep-a-Changelog entry.
+- Add tests covering new behavior.
+- Run `go vet ./...` before pushing.
+
+## Reporting issues
+
+See the issue templates under `.github/ISSUE_TEMPLATE/`.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # workflow-plugin-agent
 
+> ✅ **Verified** — used in production at **ratchet**. This plugin has been validated end-to-end in a merged main-branch wfctl.yaml of an active GoCodeAlone project.
+
 AI agent primitives for workflow apps. An internal engine plugin providing:
 
 - `agent.provider` module — AI provider abstraction (mock, test, anthropic, openai, copilot)

--- a/examples/minimal/config.yaml
+++ b/examples/minimal/config.yaml
@@ -1,0 +1,16 @@
+# Minimal workflow-plugin-agent example.
+# Configures an Anthropic AI provider module.
+#
+# Prerequisites:
+#   export ANTHROPIC_API_KEY=<your-anthropic-api-key>
+#
+# Usage:
+#   wfctl validate --skip-unknown-types examples/minimal/config.yaml
+
+modules:
+  - name: ai-provider
+    type: agent.provider
+    config:
+      provider: anthropic
+      model: claude-3-5-haiku-20241022
+      api_key: ${ANTHROPIC_API_KEY}

--- a/examples/minimal/config.yaml
+++ b/examples/minimal/config.yaml
@@ -1,5 +1,5 @@
 # Minimal workflow-plugin-agent example.
-# Configures an Anthropic AI provider module.
+# Configures an Anthropic AI provider and runs an agent task.
 #
 # Prerequisites:
 #   export ANTHROPIC_API_KEY=<your-anthropic-api-key>
@@ -14,3 +14,16 @@ modules:
       provider: anthropic
       model: claude-3-5-haiku-20241022
       api_key: ${ANTHROPIC_API_KEY}
+
+workflows:
+  run-agent:
+    trigger:
+      type: http
+      config:
+        path: /agent/run
+        method: POST
+    steps:
+      - name: execute
+        type: step.agent_execute
+        config:
+          provider_service: ai-provider


### PR DESCRIPTION
## Summary

- Prepend verified-status banner to README.md (production at ratchet).
- Add CONTRIBUTING.md from shared plugin template.
- Add `examples/minimal/config.yaml` (minimal `agent.provider` config with Anthropic; `wfctl validate --skip-unknown-types` passes).
- Add `.github/ISSUE_TEMPLATE/bug_report.md`, `feature_request.md`, and `PULL_REQUEST_TEMPLATE.md`.
- Add `CHANGELOG.md` (Keep a Changelog format) with initial `[Unreleased]` QoL sweep entry.

## Motivation

Part of the multi-repo QoL sweep (workflow#714). Brings workflow-plugin-agent up to the P0 documentation baseline.

## Test plan

- [x] `go build ./...` passes (GOWORK=off)
- [x] `go vet ./...` passes (GOWORK=off)
- [x] `wfctl validate --skip-unknown-types examples/minimal/config.yaml` → PASS

## Checklist

- [x] CHANGELOG.md updated (Keep-a-Changelog format)
- [x] No secrets or credentials included
- [x] One feature or bugfix per PR

Cross-ref: GoCodeAlone/workflow#714

🤖 Generated with [Claude Code](https://claude.com/claude-code)