### PR TITLE
ci: canonical registry notify (fix dead dispatch + drop manifest-overwrite)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,20 +67,22 @@ jobs:
               });
             }
 
-  notify-registry:
-    if: startsWith(github.ref, 'refs/tags/v')
-    needs: [publish-release]
+  notify-workflow-registry:
+    name: Notify workflow-registry
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    needs: publish-release
+    if: >-
+      !github.event.deleted
+      && !contains(github.ref_name, '-')
+      && github.repository == 'GoCodeAlone/workflow-plugin-agent'
     steps:
-      - name: Notify workflow-registry
-        if: env.GH_TOKEN != ''
-        uses: peter-evans/repository-dispatch@v3
+      - name: Trigger registry manifest sync
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697  # v4
         with:
-          token: ${{ secrets.REGISTRY_PAT }}
+          token: ${{ secrets.repo_dispatch_token }}
           repository: GoCodeAlone/workflow-registry
           event-type: plugin-release
-          client-payload: >-
-            {"plugin": "${{ github.repository }}", "tag": "${{ github.ref_name }}"}
-        env:
-          GH_TOKEN: ${{ secrets.REGISTRY_PAT }}
-        continue-on-error: true
+          client-payload: |-
+            {"plugin": "agent", "tag": "${{ github.ref_name }}"}


### PR DESCRIPTION
Aligns registry-notify with fleet-canonical aws/gcp/azure/digitalocean pattern.

**What changed:**
- Removes `notify-registry` job (peter-evans@v3, `REGISTRY_PAT`, full `github.repository` payload)
- Adds `notify-workflow-registry` job with pinned SHA `peter-evans/repository-dispatch@28959ce...` (v4), `repo_dispatch_token`, and bare plugin name `"agent"` — the form the registry manifest-sync resolver expects

**Why:** The old payload sent `"GoCodeAlone/workflow-plugin-agent"` as the plugin name, which the registry resolver cannot match to a short plugin key. The new form sends `"agent"`, matching the registry manifest lookup used by all other fleet plugins.