### PR TITLE
chore: apply plugin version discipline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
             "https://github.com/GoCodeAlone/workflow/releases/download/v0.63.2/wfctl-linux-amd64"
           chmod +x "${RUNNER_TEMP}/wfctl-bin/wfctl"
       - name: Validate plugin contract for publish (pre-build)
-        run: "${{ runner.temp }}/wfctl-bin/wfctl plugin validate-contract --for-publish --tag ${{ github.ref_name }} ."
+        run: "${{ runner.temp }}/wfctl-bin/wfctl plugin validate-contract --for-publish --tag "${{ github.ref_name }}" ."
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7
         with:
@@ -58,7 +58,7 @@ jobs:
           "${{ runner.temp }}/wfctl-bin/wfctl" plugin verify-capabilities --binary "$BIN" .
       - name: Verify shipped plugin.json carries tag (post-build)
         run: |
-          "${{ runner.temp }}/wfctl-bin/wfctl" plugin validate-contract --for-publish --tag ${{ github.ref_name }} --release-dir . .
+          "${{ runner.temp }}/wfctl-bin/wfctl" plugin validate-contract --for-publish --tag "${{ github.ref_name }}" --release-dir . .
 
   publish-release:
     if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,8 @@ jobs:
             "https://github.com/GoCodeAlone/workflow/releases/download/v0.63.2/wfctl-linux-amd64"
           chmod +x "${RUNNER_TEMP}/wfctl-bin/wfctl"
       - name: Validate plugin contract for publish (pre-build)
-        run: "${{ runner.temp }}/wfctl-bin/wfctl plugin validate-contract --for-publish --tag "${{ github.ref_name }}" ."
+        run: |
+          "${{ runner.temp }}/wfctl-bin/wfctl" plugin validate-contract --for-publish --tag "${{ github.ref_name }}" .
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,15 @@ jobs:
       - name: Configure git for private modules
         run: git config --global url."https://${{ secrets.RELEASES_TOKEN }}@github.com/".insteadOf "https://github.com/"
 
+      - name: Install wfctl v0.63.2
+        run: |
+          mkdir -p "${RUNNER_TEMP}/wfctl-bin"
+          curl -sSfL -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -o "${RUNNER_TEMP}/wfctl-bin/wfctl" \
+            "https://github.com/GoCodeAlone/workflow/releases/download/v0.63.2/wfctl-linux-amd64"
+          chmod +x "${RUNNER_TEMP}/wfctl-bin/wfctl"
+      - name: Validate plugin contract for publish (pre-build)
+        run: "${{ runner.temp }}/wfctl-bin/wfctl plugin validate-contract --for-publish --tag ${{ github.ref_name }} ."
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7
         with:
@@ -34,6 +43,22 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASES_TOKEN }}
+      # workflow#765: runtime truth-check via plugin verify-capabilities.
+      - name: Verify capabilities (runtime truth-check)
+        run: |
+          RUNNER_ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
+          BIN=$(jq -r --arg arch "$RUNNER_ARCH" \
+            '[.[] | select(.type=="Binary" and .goos=="linux" and .goarch==$arch and (.name|startswith("workflow-plugin-agent")))] | .[0].path // ""' \
+            dist/artifacts.json)
+          if [ -z "$BIN" ] || [ "$BIN" = "null" ]; then
+            echo "::warning::No matching linux/$RUNNER_ARCH binary in dist/artifacts.json; skipping verify-capabilities"
+            jq '.[] | {name, type, goos, goarch, path}' dist/artifacts.json
+            exit 0
+          fi
+          "${{ runner.temp }}/wfctl-bin/wfctl" plugin verify-capabilities --binary "$BIN" .
+      - name: Verify shipped plugin.json carries tag (post-build)
+        run: |
+          "${{ runner.temp }}/wfctl-bin/wfctl" plugin validate-contract --for-publish --tag ${{ github.ref_name }} --release-dir . .
 
   publish-release:
     if: startsWith(github.ref, 'refs/tags/v')

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,7 +1,33 @@
 version: 2
 
+before:
+  hooks:
+    - go mod tidy
+    - "sed -i.bak 's/\"version\": \".*\"/\"version\": \"{{ .Version }}\"/' plugin.json && rm -f plugin.json.bak"
+
 builds:
-  - skip: true
+  - id: workflow-plugin-agent
+    main: ./cmd/workflow-plugin-agent
+    binary: workflow-plugin-agent
+    env:
+      - CGO_ENABLED=0
+      - GOPRIVATE=github.com/GoCodeAlone/*
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w -X github.com/GoCodeAlone/workflow-plugin-agent.Version={{.Version}}
+
+archives:
+  - formats: [tar.gz]
+    name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}"
+    files:
+      - plugin.json
+      - plugin.contracts.json
+      - LICENSE
 
 changelog:
   sort: asc

--- a/cmd/workflow-plugin-agent/main.go
+++ b/cmd/workflow-plugin-agent/main.go
@@ -1,0 +1,12 @@
+// Command workflow-plugin-agent hosts the agent plugin over the workflow
+// external-plugin protocol.
+package main
+
+import (
+	agent "github.com/GoCodeAlone/workflow-plugin-agent"
+	sdk "github.com/GoCodeAlone/workflow/plugin/external/sdk"
+)
+
+func main() {
+	sdk.Serve(agent.New(), sdk.WithBuildVersion(sdk.ResolveBuildVersion(agent.Version)))
+}

--- a/plugin.go
+++ b/plugin.go
@@ -10,6 +10,7 @@ package agent
 import (
 	"github.com/GoCodeAlone/workflow/capability"
 	"github.com/GoCodeAlone/workflow/plugin"
+	sdk "github.com/GoCodeAlone/workflow/plugin/external/sdk"
 	"github.com/GoCodeAlone/workflow/schema"
 )
 
@@ -57,9 +58,9 @@ func agentStepSchemas() []*schema.StepSchema {
 			ReadKeys: []string{"alias"},
 		},
 		{
-			Type:        "step.provider_models",
-			Plugin:      "workflow-plugin-agent",
-			Description: "Lists available models from an AI provider API, accepting provider credentials from the pipeline context.",
+			Type:         "step.provider_models",
+			Plugin:       "workflow-plugin-agent",
+			Description:  "Lists available models from an AI provider API, accepting provider credentials from the pipeline context.",
 			ConfigFields: []schema.ConfigFieldDef{},
 			Outputs: []schema.StepOutputDef{
 				{Key: "success", Type: "boolean", Description: "true when model listing succeeded"},
@@ -101,12 +102,12 @@ func New() *AgentPlugin {
 		BaseEnginePlugin: plugin.BaseEnginePlugin{
 			BaseNativePlugin: plugin.BaseNativePlugin{
 				PluginName:        "agent",
-				PluginVersion:     "0.1.0",
+				PluginVersion:     "0.0.0",
 				PluginDescription: "AI agent primitives for workflow apps",
 			},
 			Manifest: plugin.PluginManifest{
 				Name:        "workflow-plugin-agent",
-				Version:     "0.1.0",
+				Version:     "0.0.0",
 				Author:      "GoCodeAlone",
 				Description: "AI agent primitives for workflow apps",
 				ModuleTypes: []string{"agent.provider"},
@@ -115,6 +116,16 @@ func New() *AgentPlugin {
 				StepSchemas: agentStepSchemas(),
 			},
 		},
+	}
+}
+
+// Manifest implements sdk.PluginProvider for external plugin hosting.
+func (p *AgentPlugin) Manifest() sdk.PluginManifest {
+	return sdk.PluginManifest{
+		Name:        "workflow-plugin-agent",
+		Version:     "0.0.0",
+		Author:      "GoCodeAlone",
+		Description: "AI agent primitives for workflow apps",
 	}
 }
 

--- a/plugin.go
+++ b/plugin.go
@@ -102,12 +102,12 @@ func New() *AgentPlugin {
 		BaseEnginePlugin: plugin.BaseEnginePlugin{
 			BaseNativePlugin: plugin.BaseNativePlugin{
 				PluginName:        "agent",
-				PluginVersion:     "0.0.0",
+				PluginVersion:     Version,
 				PluginDescription: "AI agent primitives for workflow apps",
 			},
 			Manifest: plugin.PluginManifest{
 				Name:        "workflow-plugin-agent",
-				Version:     "0.0.0",
+				Version:     Version,
 				Author:      "GoCodeAlone",
 				Description: "AI agent primitives for workflow apps",
 				ModuleTypes: []string{"agent.provider"},
@@ -123,7 +123,7 @@ func New() *AgentPlugin {
 func (p *AgentPlugin) Manifest() sdk.PluginManifest {
 	return sdk.PluginManifest{
 		Name:        "workflow-plugin-agent",
-		Version:     "0.0.0",
+		Version:     Version,
 		Author:      "GoCodeAlone",
 		Description: "AI agent primitives for workflow apps",
 	}

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-plugin-agent",
-  "version": "0.9.2",
+  "version": "0.0.0",
   "description": "AI agent primitives for workflow apps",
   "author": "GoCodeAlone",
   "license": "Proprietary",
@@ -10,8 +10,13 @@
   "private": true,
   "capabilities": {
     "configProvider": false,
-    "moduleTypes": ["agent.provider"],
-    "stepTypes": ["step.provider_models", "step.model_pull"],
+    "moduleTypes": [
+      "agent.provider"
+    ],
+    "stepTypes": [
+      "step.provider_models",
+      "step.model_pull"
+    ],
     "triggerTypes": []
   },
   "strictContracts": {

--- a/version.go
+++ b/version.go
@@ -1,0 +1,4 @@
+package agent
+
+// Version is injected by GoReleaser for release builds.
+var Version = "dev"

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package agent
 
-// Version is injected by GoReleaser for release builds.
-var Version = "dev"
+// Version is the source-tree sentinel and is injected by GoReleaser for release builds.
+var Version = "0.0.0"


### PR DESCRIPTION
Part of GoCodeAlone/workflow#760.

Changes:
- keep committed plugin.json.version at the 0.0.0 development sentinel
- remove the obsolete sync-plugin-version workflow when present
- add post-build release validation so the shipped manifest is checked against the tag
- preserve/strengthen runtime capability checks where needed

Verification:
- wfctl plugin validate-contract .
- wfctl plugin validate-contract --for-publish --tag v9.9.9 .
- GOWORK=off go test ./...
